### PR TITLE
add bq-ddl generate func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.2.0
+- Add `DdlParseTable.to_bigquery_ddl` function.
+    - BigQuery DDL (CREATE TABLE) statement generate function.
+- Add `DdlParseColumn.bigquery_legacy_data_type` property.
+    - Get BigQuery Legacy SQL data property.
+    - Alias of `DdlParseColumn.bigquery_data_type` property.
+- Add `DdlParseColumn.bigquery_standard_data_type` property.
+    - Get BigQuery Standard SQL data property.
+
 ## 1.1.3
 - Add support inline comment.
 - Add support constraint name with quotes.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Requirements Status](https://requires.io/github/shinichi-takii/ddlparse/requirements.svg?branch=master)](https://requires.io/github/shinichi-takii/ddlparse/requirements/?branch=master)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/shinichi-takii/ddlparse/blob/master/LICENSE.md)
 
-*DDL parase and Convert to BigQuery JSON schema module, available in Python.*
+*DDL parase and Convert to BigQuery JSON schema and DDL statements module, available in Python.*
 
 ----
 
@@ -16,8 +16,8 @@
 
 - DDL parse and get table schema information.
 - Currently, only the `CREATE TABLE` statement is supported.
+- Convert to [BigQuery JSON schema](https://cloud.google.com/bigquery/docs/schemas#creating_a_json_schema_file) and [BigQuery DDL statements](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language).
 - Supported databases are MySQL, PostgreSQL, Oracle, Redshift.
-- Convert to [BigQuery JSON schema](https://cloud.google.com/bigquery/docs/schemas#creating_a_json_schema_file).
 
 ## Requirement
 
@@ -50,15 +50,15 @@ $ pip install ddlparse --upgrade
 ### Example
 
 ```python
-from ddlparse import DdlParse
+from ddlparse.ddlparse import DdlParse
 
 sample_ddl = """
 CREATE TABLE My_Schema.Sample_Table (
-  ID integer PRIMARY KEY,
-  NAME varchar(100) NOT NULL,
-  TOTAL bigint NOT NULL,
-  AVG decimal(5,1) NOT NULL,
-  CREATED_AT date, -- Oracle 'DATE' -> BigQuery 'DATETIME'
+  Id integer PRIMARY KEY,
+  Name varchar(100) NOT NULL,
+  Total bigint NOT NULL,
+  Avg decimal(5,1) NOT NULL,
+  Created_At date, -- Oracle 'DATE' -> BigQuery 'DATETIME'
   UNIQUE (NAME)
 );
 """
@@ -111,18 +111,28 @@ print(table.to_bigquery_fields(DdlParse.NAME_CASE.upper))
 
 print("* COLUMN *")
 for col in table.columns.values():
-    print("name = {} : data_type = {} : length = {} : precision(=length) = {} : scale = {} : constraint = {} : not_null =  {} : PK =  {} : unique =  {} : BQ {}".format(
-        col.name,
-        col.data_type,
-        col.length,
-        col.precision,
-        col.scale,
-        col.constraint,
-        col.not_null,
-        col.primary_key,
-        col.unique,
-        col.to_bigquery_field()
-        ))
+    col_info = []
+    col_info.append("name = {}".format(col.name))
+    col_info.append("data_type = {}".format(col.data_type))
+    col_info.append("length = {}".format(col.length))
+    col_info.append("precision(=length) = {}".format(col.precision))
+    col_info.append("scale = {}".format(col.scale))
+    col_info.append("constraint = {}".format(col.constraint))
+    col_info.append("not_null =  {}".format(col.not_null))
+    col_info.append("PK =  {}".format(col.primary_key))
+    col_info.append("unique =  {}".format(col.unique))
+    col_info.append("bq_data_type =  {}".format(col.bigquery_data_type))
+    col_info.append("bq_legacy_data_type =  {}".format(col.bigquery_legacy_data_type))
+    col_info.append("bq_standard_data_type =  {}".format(col.bigquery_standard_data_type))
+    col_info.append("BQ {}".format(col.to_bigquery_field()))
+    print(" : ".join(col_info))
+
+print("* DDL (CREATE TABLE) statements *")
+print(table.to_bigquery_ddl())
+
+print("* DDL (CREATE TABLE) statements - dataset name, table name and column name to lower case / upper case *")
+print(table.to_bigquery_ddl(DdlParse.NAME_CASE.lower))
+print(table.to_bigquery_ddl(DdlParse.NAME_CASE.upper))
 
 print("* Get Column object (case insensitive) *")
 print(table.columns["total"])

--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,36 @@
 DDL Parse
 =========
 
-`PyPI version <https://pypi.python.org/pypi/ddlparse>`__ `Python
-version <https://pypi.python.org/pypi/ddlparse>`__ `Travis CI Build
-Status <https://travis-ci.org/shinichi-takii/ddlparse>`__ `Coveralls
-Coverage
-Status <https://coveralls.io/github/shinichi-takii/ddlparse?branch=master>`__
-`codecov Coverage
-Status <https://codecov.io/gh/shinichi-takii/ddlparse>`__ `Requirements
-Status <https://requires.io/github/shinichi-takii/ddlparse/requirements/?branch=master>`__
-`License <https://github.com/shinichi-takii/ddlparse/blob/master/LICENSE.md>`__
+.. image:: https://img.shields.io/pypi/v/ddlparse.svg
+   :target: https://pypi.python.org/pypi/ddlparse
+   :alt: PyPI version
 
-*DDL parase and Convert to BigQuery JSON schema module, available in
-Python.*
+.. image:: https://img.shields.io/pypi/pyversions/ddlparse.svg
+   :target: https://pypi.python.org/pypi/ddlparse
+   :alt: Python version
+
+.. image:: https://travis-ci.org/shinichi-takii/ddlparse.svg?branch=master
+   :target: https://travis-ci.org/shinichi-takii/ddlparse
+   :alt: Travis CI Build Status
+
+.. image:: https://coveralls.io/repos/github/shinichi-takii/ddlparse/badge.svg?branch=master
+   :target: https://coveralls.io/github/shinichi-takii/ddlparse?branch=master
+   :alt: Coveralls Coverage Status
+
+.. image:: https://codecov.io/gh/shinichi-takii/ddlparse/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/shinichi-takii/ddlparse
+   :alt: codecov Coverage Status
+
+.. image:: https://requires.io/github/shinichi-takii/ddlparse/requirements.svg?branch=master
+   :target: https://requires.io/github/shinichi-takii/ddlparse/requirements/?branch=master
+   :alt: Requirements Status
+
+.. image:: https://img.shields.io/badge/License-BSD%203--Clause-blue.svg
+   :target: https://github.com/shinichi-takii/ddlparse/blob/master/LICENSE.md
+   :alt: License
+
+*DDL parase and Convert to BigQuery JSON schema and DDL statements
+module, available in Python.*
 
 --------------
 
@@ -21,9 +39,11 @@ Features
 
 -  DDL parse and get table schema information.
 -  Currently, only the ``CREATE TABLE`` statement is supported.
--  Supported databases are MySQL, PostgreSQL, Oracle, Redshift.
 -  Convert to `BigQuery JSON
-   schema <https://cloud.google.com/bigquery/docs/schemas#creating_a_json_schema_file>`__.
+   schema <https://cloud.google.com/bigquery/docs/schemas#creating_a_json_schema_file>`__
+   and `BigQuery DDL
+   statements <https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language>`__.
+-  Supported databases are MySQL, PostgreSQL, Oracle, Redshift.
 
 Requirement
 -----------
@@ -66,15 +86,15 @@ Example
 
 .. code:: python
 
-   from ddlparse import DdlParse
+   from ddlparse.ddlparse import DdlParse
 
    sample_ddl = """
    CREATE TABLE My_Schema.Sample_Table (
-     ID integer PRIMARY KEY,
-     NAME varchar(100) NOT NULL,
-     TOTAL bigint NOT NULL,
-     AVG decimal(5,1) NOT NULL,
-     CREATED_AT date, -- Oracle 'DATE' -> BigQuery 'DATETIME'
+     Id integer PRIMARY KEY,
+     Name varchar(100) NOT NULL,
+     Total bigint NOT NULL,
+     Avg decimal(5,1) NOT NULL,
+     Created_At date, -- Oracle 'DATE' -> BigQuery 'DATETIME'
      UNIQUE (NAME)
    );
    """
@@ -127,18 +147,28 @@ Example
 
    print("* COLUMN *")
    for col in table.columns.values():
-       print("name = {} : data_type = {} : length = {} : precision(=length) = {} : scale = {} : constraint = {} : not_null =  {} : PK =  {} : unique =  {} : BQ {}".format(
-           col.name,
-           col.data_type,
-           col.length,
-           col.precision,
-           col.scale,
-           col.constraint,
-           col.not_null,
-           col.primary_key,
-           col.unique,
-           col.to_bigquery_field()
-           ))
+       col_info = []
+       col_info.append("name = {}".format(col.name))
+       col_info.append("data_type = {}".format(col.data_type))
+       col_info.append("length = {}".format(col.length))
+       col_info.append("precision(=length) = {}".format(col.precision))
+       col_info.append("scale = {}".format(col.scale))
+       col_info.append("constraint = {}".format(col.constraint))
+       col_info.append("not_null =  {}".format(col.not_null))
+       col_info.append("PK =  {}".format(col.primary_key))
+       col_info.append("unique =  {}".format(col.unique))
+       col_info.append("bq_data_type =  {}".format(col.bigquery_data_type))
+       col_info.append("bq_legacy_data_type =  {}".format(col.bigquery_legacy_data_type))
+       col_info.append("bq_standard_data_type =  {}".format(col.bigquery_standard_data_type))
+       col_info.append("BQ {}".format(col.to_bigquery_field()))
+       print(" : ".join(col_info))
+
+   print("* DDL (CREATE TABLE) statements *")
+   print(table.to_bigquery_ddl())
+
+   print("* DDL (CREATE TABLE) statements - dataset name, table name and column name to lower case / upper case *")
+   print(table.to_bigquery_ddl(DdlParse.NAME_CASE.lower))
+   print(table.to_bigquery_ddl(DdlParse.NAME_CASE.upper))
 
    print("* Get Column object (case insensitive) *")
    print(table.columns["total"])

--- a/ddlparse/__init__.py
+++ b/ddlparse/__init__.py
@@ -7,8 +7,8 @@
 
 from .ddlparse import *
 
-__copyright__    = 'Copyright (C) 2018 Shinichi Takii'
-__version__      = '1.1.3'
+__copyright__    = 'Copyright (C) 2018-2019 Shinichi Takii'
+__version__      = '1.2.0'
 __license__      = 'BSD-3-Clause'
 __author__       = 'Shinichi Takii'
 __author_email__ = 'shinichi.takii@gmail.com'

--- a/example/example.py
+++ b/example/example.py
@@ -9,11 +9,11 @@ from ddlparse import DdlParse
 
 sample_ddl = """
 CREATE TABLE My_Schema.Sample_Table (
-  ID integer PRIMARY KEY,
-  NAME varchar(100) NOT NULL,
-  TOTAL bigint NOT NULL,
-  AVG decimal(5,1) NOT NULL,
-  CREATED_AT date, -- Oracle 'DATE' -> BigQuery 'DATETIME'
+  Id integer PRIMARY KEY,
+  Name varchar(100) NOT NULL,
+  Total bigint NOT NULL,
+  Avg decimal(5,1) NOT NULL,
+  Created_At date, -- Oracle 'DATE' -> BigQuery 'DATETIME'
   UNIQUE (NAME)
 );
 """
@@ -66,18 +66,28 @@ print(table.to_bigquery_fields(DdlParse.NAME_CASE.upper))
 
 print("* COLUMN *")
 for col in table.columns.values():
-    print("name = {} : data_type = {} : length = {} : precision(=length) = {} : scale = {} : constraint = {} : not_null =  {} : PK =  {} : unique =  {} : BQ {}".format(
-        col.name,
-        col.data_type,
-        col.length,
-        col.precision,
-        col.scale,
-        col.constraint,
-        col.not_null,
-        col.primary_key,
-        col.unique,
-        col.to_bigquery_field()
-        ))
+    col_info = []
+    col_info.append("name = {}".format(col.name))
+    col_info.append("data_type = {}".format(col.data_type))
+    col_info.append("length = {}".format(col.length))
+    col_info.append("precision(=length) = {}".format(col.precision))
+    col_info.append("scale = {}".format(col.scale))
+    col_info.append("constraint = {}".format(col.constraint))
+    col_info.append("not_null =  {}".format(col.not_null))
+    col_info.append("PK =  {}".format(col.primary_key))
+    col_info.append("unique =  {}".format(col.unique))
+    col_info.append("bq_data_type =  {}".format(col.bigquery_data_type))
+    col_info.append("bq_legacy_data_type =  {}".format(col.bigquery_legacy_data_type))
+    col_info.append("bq_standard_data_type =  {}".format(col.bigquery_standard_data_type))
+    col_info.append("BQ {}".format(col.to_bigquery_field()))
+    print(" : ".join(col_info))
+
+print("* DDL (CREATE TABLE) statements *")
+print(table.to_bigquery_ddl())
+
+print("* DDL (CREATE TABLE) statements - dataset name, table name and column name to lower case / upper case *")
+print(table.to_bigquery_ddl(DdlParse.NAME_CASE.lower))
+print(table.to_bigquery_ddl(DdlParse.NAME_CASE.upper))
 
 print("* Get Column object (case insensitive) *")
 print(table.columns["total"])

--- a/test/test_ddlparse.py
+++ b/test/test_ddlparse.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import pytest, re
+import pytest, re, textwrap
 from enum import IntEnum
 
 from ddlparse.ddlparse import DdlParse
@@ -107,6 +107,37 @@ TEST_DATA = {
             '{"name": "Col_28", "type": "FLOAT", "mode": "NULLABLE"}',
             '{"name": "Col_29", "type": "FLOAT", "mode": "NULLABLE"}',
         ],
+        "bq_standard_data_type" : [
+            "STRING",
+            "STRING",
+            "STRING",
+            "INT64",
+            "INT64",
+            "INT64",
+            "INT64",
+            "FLOAT64",
+            "FLOAT64",
+            "FLOAT64",
+            "FLOAT64",
+            "FLOAT64",
+            "DATE",
+            "TIME",
+            "DATETIME",
+            "DATETIME",
+            "DATETIME",
+            "TIMESTAMP",
+            "TIMESTAMP",
+            "BOOL",
+            "INT64",
+            "INT64",
+            "INT64",
+            "INT64",
+            "INT64",
+            "INT64",
+            "FLOAT64",
+            "FLOAT64",
+            "FLOAT64",
+        ],
     },
 
     "constraint_mysql" :
@@ -138,6 +169,13 @@ TEST_DATA = {
             '{"name": "Col_03", "type": "INTEGER", "mode": "NULLABLE"}',
             '{"name": "Col_04", "type": "FLOAT", "mode": "NULLABLE"}',
             '{"name": "Col_05", "type": "DATETIME", "mode": "NULLABLE"}',
+        ],
+        "bq_standard_data_type" : [
+            "STRING",
+            "STRING",
+            "INT64",
+            "FLOAT64",
+            "DATETIME",
         ],
     },
 
@@ -173,6 +211,13 @@ TEST_DATA = {
             '{"name": "Col_04", "type": "FLOAT", "mode": "REQUIRED"}',
             '{"name": "Col_05", "type": "DATETIME", "mode": "REQUIRED"}',
         ],
+        "bq_standard_data_type" : [
+            "STRING",
+            "STRING",
+            "INT64",
+            "FLOAT64",
+            "DATETIME",
+        ],
     },
 
     "default_postgres_redshift" :
@@ -193,6 +238,10 @@ TEST_DATA = {
         "bq_field" : [
             '{"name": "Col_01", "type": "STRING", "mode": "NULLABLE"}',
             '{"name": "Col_02", "type": "STRING", "mode": "NULLABLE"}',
+        ],
+        "bq_standard_data_type" : [
+            "STRING",
+            "STRING",
         ],
     },
 
@@ -233,6 +282,16 @@ TEST_DATA = {
             '{"name": "Col_07", "type": "STRING", "mode": "NULLABLE"}',
             '{"name": "Col_08", "type": "STRING", "mode": "NULLABLE"}',
         ],
+        "bq_standard_data_type" : [
+            "DATETIME",
+            "INT64",
+            "FLOAT64",
+            "FLOAT64",
+            "STRING",
+            "STRING",
+            "STRING",
+            "STRING",
+        ],
     },
 
     "name_backquote" :
@@ -264,6 +323,13 @@ TEST_DATA = {
             '{"name": "Col_03", "type": "INTEGER", "mode": "NULLABLE"}',
             '{"name": "Col_04", "type": "FLOAT", "mode": "NULLABLE"}',
             '{"name": "Col_05", "type": "DATETIME", "mode": "NULLABLE"}',
+        ],
+        "bq_standard_data_type" : [
+            "STRING",
+            "STRING",
+            "INT64",
+            "FLOAT64",
+            "DATETIME",
         ],
     },
 
@@ -297,6 +363,13 @@ TEST_DATA = {
             '{"name": "Col_04", "type": "FLOAT", "mode": "NULLABLE"}',
             '{"name": "Col_05", "type": "DATETIME", "mode": "NULLABLE"}',
         ],
+        "bq_standard_data_type" : [
+            "STRING",
+            "STRING",
+            "INT64",
+            "FLOAT64",
+            "DATETIME",
+        ],
     },
 
     "temp_table" :
@@ -314,6 +387,9 @@ TEST_DATA = {
         ],
         "bq_field" : [
             '{"name": "Col_01", "type": "STRING", "mode": "NULLABLE"}',
+        ],
+        "bq_standard_data_type" : [
+            "STRING",
         ],
     },
 
@@ -333,6 +409,115 @@ TEST_DATA = {
         "bq_field" : [
             '{"name": "Col_01", "type": "STRING", "mode": "NULLABLE"}',
         ],
+        "bq_standard_data_type" : [
+            "STRING",
+        ],
+    },
+}
+
+
+TEST_DATA_DDL = {
+    "exist_schema_name": {
+        "source_ddl":
+            """
+            CREATE TABLE Test_Schema.Test_Table (
+              Col_01 varchar(100) PRIMARY KEY,
+              Col_02 char(200) NOT NULL UNIQUE,
+              Col_03 integer UNIQUE,
+              Col_04 double,
+              Col_05 datetime NOT NULL,
+              Col_06 bool
+            );
+            """,
+        "bq_ddl": {
+            DdlParse.NAME_CASE.original:
+                """\
+                #standardSQL
+                CREATE TABLE `project.Test_Schema.Test_Table`
+                (
+                  Col_01 STRING NOT NULL,
+                  Col_02 STRING NOT NULL,
+                  Col_03 INT64,
+                  Col_04 FLOAT64,
+                  Col_05 DATETIME NOT NULL,
+                  Col_06 BOOL
+                )""",
+            DdlParse.NAME_CASE.lower:
+                """\
+                #standardSQL
+                CREATE TABLE `project.test_schema.test_table`
+                (
+                  col_01 STRING NOT NULL,
+                  col_02 STRING NOT NULL,
+                  col_03 INT64,
+                  col_04 FLOAT64,
+                  col_05 DATETIME NOT NULL,
+                  col_06 BOOL
+                )""",
+            DdlParse.NAME_CASE.upper:
+                """\
+                #standardSQL
+                CREATE TABLE `project.TEST_SCHEMA.TEST_TABLE`
+                (
+                  COL_01 STRING NOT NULL,
+                  COL_02 STRING NOT NULL,
+                  COL_03 INT64,
+                  COL_04 FLOAT64,
+                  COL_05 DATETIME NOT NULL,
+                  COL_06 BOOL
+                )""",
+        },
+    },
+    "no_schema_name": {
+        "source_ddl":
+            """
+            CREATE TABLE Test_Table (
+              Col_01 varchar(100) PRIMARY KEY,
+              Col_02 char(200) NOT NULL UNIQUE,
+              Col_03 integer UNIQUE,
+              Col_04 double,
+              Col_05 datetime NOT NULL,
+              Col_06 bool
+            );
+            """,
+        "bq_ddl": {
+            DdlParse.NAME_CASE.original:
+                """\
+                #standardSQL
+                CREATE TABLE `project.dataset.Test_Table`
+                (
+                  Col_01 STRING NOT NULL,
+                  Col_02 STRING NOT NULL,
+                  Col_03 INT64,
+                  Col_04 FLOAT64,
+                  Col_05 DATETIME NOT NULL,
+                  Col_06 BOOL
+                )""",
+            DdlParse.NAME_CASE.lower:
+                """\
+                #standardSQL
+                CREATE TABLE `project.dataset.test_table`
+                (
+                  col_01 STRING NOT NULL,
+                  col_02 STRING NOT NULL,
+                  col_03 INT64,
+                  col_04 FLOAT64,
+                  col_05 DATETIME NOT NULL,
+                  col_06 BOOL
+                )""",
+            DdlParse.NAME_CASE.upper:
+                """\
+                #standardSQL
+                CREATE TABLE `project.dataset.TEST_TABLE`
+                (
+                  COL_01 STRING NOT NULL,
+                  COL_02 STRING NOT NULL,
+                  COL_03 INT64,
+                  COL_04 FLOAT64,
+                  COL_05 DATETIME NOT NULL,
+                  COL_06 BOOL
+                )""",
+        },
     },
 }
 
@@ -415,6 +600,9 @@ def test_parse(test_case, parse_pattern):
         data_bq_field_upper.append(re.sub(r'({"name": ")Col', r'\1COL', data_bq_field))
         assert col.to_bigquery_field(col.NAME_CASE.upper) == data_bq_field_upper[-1]
 
+        assert col.bigquery_legacy_data_type == col.bigquery_data_type
+        assert col.bigquery_standard_data_type == data["bq_standard_data_type"][i]
+
         i += 1
 
 
@@ -428,6 +616,24 @@ def test_parse(test_case, parse_pattern):
     assert table.columns.to_bigquery_fields() == table.to_bigquery_fields()
     assert table.columns.to_bigquery_fields(col.NAME_CASE.lower) == table.to_bigquery_fields(col.NAME_CASE.lower)
     assert table.columns.to_bigquery_fields(col.NAME_CASE.upper) == table.to_bigquery_fields(col.NAME_CASE.upper)
+
+
+@pytest.mark.parametrize(("test_case"), [
+    ("exist_schema_name"),
+    ("no_schema_name"),
+])
+def test_bq_ddl(test_case):
+    # Get test data
+    data = TEST_DATA_DDL[test_case]
+
+    # Parse ddl
+    table = DdlParse().parse(data["source_ddl"])
+
+    # Check generate BigQuery DDL statements of DdlParseTable
+    assert table.to_bigquery_ddl() == textwrap.dedent(data["bq_ddl"][DdlParse.NAME_CASE.original])
+    assert table.to_bigquery_ddl(DdlParse.NAME_CASE.original) == textwrap.dedent(data["bq_ddl"][DdlParse.NAME_CASE.original])
+    assert table.to_bigquery_ddl(DdlParse.NAME_CASE.lower) == textwrap.dedent(data["bq_ddl"][DdlParse.NAME_CASE.lower])
+    assert table.to_bigquery_ddl(DdlParse.NAME_CASE.upper) == textwrap.dedent(data["bq_ddl"][DdlParse.NAME_CASE.upper])
 
 
 def test_exception_ddl():


### PR DESCRIPTION
### Changes

- Add `DdlParseTable.to_bigquery_ddl` function.
    - BigQuery DDL (CREATE TABLE) statement generate function.
- Add `DdlParseColumn.bigquery_legacy_data_type` property.
    - Get BigQuery Legacy SQL data property.
    - Alias of `DdlParseColumn.bigquery_data_type` property.
- Add `DdlParseColumn.bigquery_standard_data_type` property.
    - Get BigQuery Standard SQL data property.

### Applicable Issues

- fix #20 - Add BigQuery DDL statement generate function
- fix #21 - Add BigQuery Legacy SQL data type property
- fix #22 - Add BigQuery Standard SQL data type property
