### PR TITLE
add supports PostgreSQL data type and FutureWarning of Python 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.2.2
+- Fix FutureWarning of Python 3.7.
+- Add supports PostgreSQL data type.
+    - `UUID`
+- Fix parse `DEFAULT` value.
+    - Add parse regex of `DEFAULT` value.
+
 ## 1.2.1
 - Add supports for Python 3.7.
     - Pass Python 3.7 test.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ for col in table.columns.values():
     col_info.append("not_null =  {}".format(col.not_null))
     col_info.append("PK =  {}".format(col.primary_key))
     col_info.append("unique =  {}".format(col.unique))
-    col_info.append("bq_data_type =  {}".format(col.bigquery_data_type))
     col_info.append("bq_legacy_data_type =  {}".format(col.bigquery_legacy_data_type))
     col_info.append("bq_standard_data_type =  {}".format(col.bigquery_standard_data_type))
     col_info.append("BQ {}".format(col.to_bigquery_field()))

--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,6 @@ Example
        col_info.append("not_null =  {}".format(col.not_null))
        col_info.append("PK =  {}".format(col.primary_key))
        col_info.append("unique =  {}".format(col.unique))
-       col_info.append("bq_data_type =  {}".format(col.bigquery_data_type))
        col_info.append("bq_legacy_data_type =  {}".format(col.bigquery_legacy_data_type))
        col_info.append("bq_standard_data_type =  {}".format(col.bigquery_standard_data_type))
        col_info.append("BQ {}".format(col.to_bigquery_field()))

--- a/ddlparse/__init__.py
+++ b/ddlparse/__init__.py
@@ -8,7 +8,7 @@
 from .ddlparse import *
 
 __copyright__    = 'Copyright (C) 2018-2019 Shinichi Takii'
-__version__      = '1.2.1'
+__version__      = '1.2.2'
 __license__      = 'BSD-3-Clause'
 __author__       = 'Shinichi Takii'
 __author_email__ = 'shinichi.takii@gmail.com'

--- a/ddlparse/ddlparse.py
+++ b/ddlparse/ddlparse.py
@@ -175,7 +175,7 @@ class DdlParseColumn(DdlParseTableColumnBase):
 
         # BigQuery data type = {source_database: [data type, ...], ...}
         BQ_DATA_TYPE_DIC = OrderedDict()
-        BQ_DATA_TYPE_DIC["STRING"] = {None: [re.compile(r"(CHAR|TEXT|CLOB|JSON)")]}
+        BQ_DATA_TYPE_DIC["STRING"] = {None: [re.compile(r"(CHAR|TEXT|CLOB|JSON|UUID)")]}
         BQ_DATA_TYPE_DIC["INTEGER"] = {None: [re.compile(r"INT|SERIAL|YEAR")]}
         BQ_DATA_TYPE_DIC["FLOAT"] = {None: [re.compile(r"(FLOAT|DOUBLE)"), "REAL", "MONEY"]}
         BQ_DATA_TYPE_DIC["DATETIME"] = {
@@ -483,8 +483,8 @@ class DdlParse(DdlParseBase):
                         + Optional(CaselessKeyword("WITHOUT TIME ZONE") ^ CaselessKeyword("WITH TIME ZONE") ^ CaselessKeyword("PRECISION") ^ CaselessKeyword("VARYING"))
                         + Optional(_LPAR + Regex(r"\d+\s*,*\s*\d*") + Optional(Suppress(_CHAR_SEMANTICS | _BYTE_SEMANTICS)) + _RPAR)
                         )("type")
-                    + Optional(Word("[]"))("array_brackets")
-                    + Optional(Word(alphanums+"_': -."))("constraint")
+                    + Optional(Word(r"\[\]"))("array_brackets")
+                    + Optional(Regex(r"DEFAULT\s+[^,]+", re.IGNORECASE) | Word(alphanums+"_': -"))("constraint")
                 )("column")
             )
         )("columns")

--- a/example/example.py
+++ b/example/example.py
@@ -76,7 +76,6 @@ for col in table.columns.values():
     col_info.append("not_null =  {}".format(col.not_null))
     col_info.append("PK =  {}".format(col.primary_key))
     col_info.append("unique =  {}".format(col.unique))
-    col_info.append("bq_data_type =  {}".format(col.bigquery_data_type))
     col_info.append("bq_legacy_data_type =  {}".format(col.bigquery_legacy_data_type))
     col_info.append("bq_standard_data_type =  {}".format(col.bigquery_standard_data_type))
     col_info.append("BQ {}".format(col.to_bigquery_field()))

--- a/test/test_ddlparse.py
+++ b/test/test_ddlparse.py
@@ -229,7 +229,8 @@ TEST_DATA = {
               Col_02 char(1) DEFAULT '0'::bpchar,
               Col_03 integer DEFAULT 0,
               Col_04 numeric(10) DEFAULT 0,
-              Col_05 numeric(20,3) DEFAULT 0.0
+              Col_05 numeric(20,3) DEFAULT 0.0,
+              Col_06 character varying[] DEFAULT '{}'::character varying[]
             );
             """,
         "database" : None,
@@ -240,6 +241,7 @@ TEST_DATA = {
             {"name" : "Col_03", "type" : "INTEGER", "length" : None, "scale" : None, "array_dimensional" : 0, "not_null" : False, "pk" : False, "unique" : False, "constraint" : ""},
             {"name" : "Col_04", "type" : "NUMERIC", "length" : 10, "scale" : None, "array_dimensional" : 0, "not_null" : False, "pk" : False, "unique" : False, "constraint" : ""},
             {"name" : "Col_05", "type" : "NUMERIC", "length" : 20, "scale" : 3, "array_dimensional" : 0, "not_null" : False, "pk" : False, "unique" : False, "constraint" : ""},
+            {"name" : "Col_06", "type" : "CHARACTER VARYING", "length" : None, "scale" : None, "array_dimensional" : 1, "not_null" : False, "pk" : False, "unique" : False, "constraint" : ""},
         ],
         "bq_field" : [
             '{"name": "Col_01", "type": "STRING", "mode": "NULLABLE"}',
@@ -247,6 +249,7 @@ TEST_DATA = {
             '{"name": "Col_03", "type": "INTEGER", "mode": "NULLABLE"}',
             '{"name": "Col_04", "type": "INTEGER", "mode": "NULLABLE"}',
             '{"name": "Col_05", "type": "FLOAT", "mode": "NULLABLE"}',
+            '{"name": "Col_06", "type": "STRING", "mode": "REPEATED"}',
         ],
         "bq_standard_data_type" : [
             "STRING",
@@ -254,6 +257,7 @@ TEST_DATA = {
             "INT64",
             "INT64",
             "FLOAT64",
+            "STRING",
         ],
     },
 
@@ -316,7 +320,8 @@ TEST_DATA = {
               Col_03 integer[], -- one dimensional array
               Col_04 integer[][], -- two dimensional array
               Col_05 integer[][][], -- multiple dimensional array
-              Col_06 character varying[] -- character varying array
+              Col_06 character varying[], -- character varying array
+              Col_07 uuid NOT NULL
             );
             """,
         "database" : None,
@@ -328,6 +333,7 @@ TEST_DATA = {
             {"name" : "Col_04", "type" : "INTEGER", "length" : None, "scale" : None, "array_dimensional" : 2, "not_null" : False, "pk" : False, "unique" : False, "constraint" : ""},
             {"name" : "Col_05", "type" : "INTEGER", "length" : None, "scale" : None, "array_dimensional" : 3, "not_null" : False, "pk" : False, "unique" : False, "constraint" : ""},
             {"name" : "Col_06", "type" : "CHARACTER VARYING", "length" : None, "scale" : None, "array_dimensional" : 1, "not_null" : False, "pk" : False, "unique" : False, "constraint" : ""},
+            {"name" : "Col_07", "type" : "UUID", "length" : None, "scale" : None, "array_dimensional" : 0, "not_null" : True, "pk" : False, "unique" : False, "constraint" : "NOT NULL"},
         ],
         "bq_field" : [
             '{"name": "Col_01", "type": "STRING", "mode": "REQUIRED"}',
@@ -336,6 +342,7 @@ TEST_DATA = {
             '{"name": "Col_04", "type": "RECORD", "mode": "REPEATED", "fields": [{"name": "dimension_1", "type": "INTEGER", "mode": "REPEATED"}]}',
             '{"name": "Col_05", "type": "RECORD", "mode": "REPEATED", "fields": [{"name": "dimension_1", "type": "RECORD", "mode": "REPEATED", "fields": [{"name": "dimension_2", "type": "INTEGER", "mode": "REPEATED"}]}]}',
             '{"name": "Col_06", "type": "STRING", "mode": "REPEATED"}',
+            '{"name": "Col_07", "type": "STRING", "mode": "REQUIRED"}',
         ],
         "bq_standard_data_type" : [
             "STRING",
@@ -343,6 +350,7 @@ TEST_DATA = {
             "INT64",
             "INT64",
             "INT64",
+            "STRING",
             "STRING",
         ],
     },


### PR DESCRIPTION
### Changes

- Fix FutureWarning of Python 3.7.
- Add supports PostgreSQL data type.
    - `UUID`
- Fix parse `DEFAULT` value.
    - Add parse regex of `DEFAULT` value.

### Applicable Issues

- fix #25 - Does not support PostgreSQL array and json
- fix #28 - Support for UUID in PostgreSQL
- fix #29 - Python3.7 : FutureWarning: Possible nested set at position 1
