### PR TITLE
Add supports for parsing MySQL CHARACTER SET and FOREIGN KEY options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.8.0] - 2020-08-22
+### Added
+- Add `DdlParseColumn.character_set` property.
+- Add supports for parsing MySQL FOREIGN KEY options MATCH, ON DELETE and ON UPDATE
+
 ## [1.7.0] - 2020-08-13
 ### Added
 - Add `DdlParseColumn.default` property.
@@ -178,6 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial released.
 
 
+[1.8.0]: https://github.com/shinichi-takii/ddlparse/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/shinichi-takii/ddlparse/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/shinichi-takii/ddlparse/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/shinichi-takii/ddlparse/compare/v1.5.0...v1.6.0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - DDL parse and get table schema information.
 - Currently, only the `CREATE TABLE` statement is supported.
 - Convert to [BigQuery JSON schema](https://cloud.google.com/bigquery/docs/schemas#creating_a_json_schema_file) and [BigQuery DDL statements](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language).
-- Supported databases are MySQL, PostgreSQL, Oracle, Redshift.
+- Supported databases are MySQL/MariaDB, PostgreSQL, Oracle, Redshift.
 
 ## Requirement
 
@@ -133,6 +133,7 @@ for col in table.columns.values():
     col_info["sortkey"]               = col.sortkey
     col_info["encode"]                = col.encode
     col_info["default"]               = col.default
+    col_info["character_set"]         = col.character_set
     col_info["bq_legacy_data_type"]   = col.bigquery_legacy_data_type
     col_info["bq_standard_data_type"] = col.bigquery_standard_data_type
     col_info["comment"]               = col.comment

--- a/ddlparse/__init__.py
+++ b/ddlparse/__init__.py
@@ -8,7 +8,7 @@
 from .ddlparse import *
 
 __copyright__    = 'Copyright (C) 2018-2020 Shinichi Takii'
-__version__      = '1.7.0'
+__version__      = '1.8.0'
 __license__      = 'BSD-3-Clause'
 __author__       = 'Shinichi Takii'
 __author_email__ = 'shinichi.takii@shaketh.com'

--- a/example/example.py
+++ b/example/example.py
@@ -88,6 +88,7 @@ for col in table.columns.values():
     col_info["sortkey"]               = col.sortkey
     col_info["encode"]                = col.encode
     col_info["default"]               = col.default
+    col_info["character_set"]         = col.character_set
     col_info["bq_legacy_data_type"]   = col.bigquery_legacy_data_type
     col_info["bq_standard_data_type"] = col.bigquery_standard_data_type
     col_info["comment"]               = col.comment

--- a/test/test_ddlparse.py
+++ b/test/test_ddlparse.py
@@ -232,7 +232,7 @@ TEST_DATA = {
             """
             CREATE TABLE Sample_Table (
               Col_01 varchar(100),
-              Col_02 char(200),
+              Col_02 char(200) CHARACTER SET latin1,
               Col_03 integer,
               Col_04 double,
               Col_05 datetime,
@@ -240,19 +240,23 @@ TEST_DATA = {
               Col_07 integer,
               CONSTRAINT const_01 PRIMARY KEY (Col_01, Col_02),
               CONSTRAINT \"const_02\" UNIQUE (Col_03, Col_04),
-              CONSTRAINT \"const_03\" FOREIGN KEY (Col_04, \"Col_05\") REFERENCES ref_table_01 (\"Col_04\", Col_05)
+              CONSTRAINT \"const_03\" FOREIGN KEY (Col_04, \"Col_05\")
+                REFERENCES ref_table_01 (\"Col_04\", Col_05)
+                MATCH FULL
+                ON DELETE SET NULL
+                ON UPDATE NO ACTION
             );
             """,
         "database": DdlParse.DATABASE.mysql,
         "table": {"schema": None, "name": "Sample_Table", "temp": False},
         "columns": [
-            {"name": "Col_01", "type": "VARCHAR", "length": 100, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": True, "pk": True, "unique": False, "constraint": "PRIMARY KEY", "description": None},
-            {"name": "Col_02", "type": "CHAR", "length": 200, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": True, "pk": True, "unique": False, "constraint": "PRIMARY KEY", "description": None},
-            {"name": "Col_03", "type": "INTEGER", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": True, "constraint": "UNIQUE", "description": None},
-            {"name": "Col_04", "type": "DOUBLE", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": True, "constraint": "UNIQUE", "description": None},
-            {"name": "Col_05", "type": "DATETIME", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
-            {"name": "Col_06", "type": "DECIMAL", "length": 2, "scale": 1, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": True, "pk": False, "unique": False, "constraint": "NOT NULL", "description": None, "default": "0.0"},
-            {"name": "Col_07", "type": "INTEGER", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
+            {"name": "Col_01", "type": "VARCHAR", "length": 100, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": True, "pk": True, "unique": False, "constraint": "PRIMARY KEY"},
+            {"name": "Col_02", "type": "CHAR", "length": 200, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": True, "pk": True, "unique": False, "constraint": "PRIMARY KEY", "character_set": "latin1"},
+            {"name": "Col_03", "type": "INTEGER", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": True, "constraint": "UNIQUE"},
+            {"name": "Col_04", "type": "DOUBLE", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": True, "constraint": "UNIQUE"},
+            {"name": "Col_05", "type": "DATETIME", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": ""},
+            {"name": "Col_06", "type": "DECIMAL", "length": 2, "scale": 1, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": True, "pk": False, "unique": False, "constraint": "NOT NULL", "default": "0.0"},
+            {"name": "Col_07", "type": "INTEGER", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": ""},
         ],
         "bq_field": [
             '{"name": "Col_01", "type": "STRING", "mode": "REQUIRED"}',
@@ -1185,6 +1189,7 @@ def test_parse(test_case, parse_pattern):
             'sortkey': False,
             'encode': None,
             'default': None,
+            'character_set': None,
         }
 
         for constraint_name, default_val in _DEFAULT_CONSTRAINT.items():
@@ -1212,6 +1217,7 @@ def test_parse(test_case, parse_pattern):
         assert col.sortkey           == data_col["sortkey"]
         assert col.encode            == data_col["encode"]
         assert col.default           == data_col["default"]
+        assert col.character_set     == data_col["character_set"]
 
         data_bq_field = data["bq_field"][i]
         assert col.to_bigquery_field() == data_bq_field


### PR DESCRIPTION
## Summary
<!-- Changelog format : https://keepachangelog.com/ -->

### Added
- Add `DdlParseColumn.character_set` property.
- Add supports for parsing MySQL FOREIGN KEY options MATCH, ON DELETE and ON UPDATE


## File Details
### CHANGELOG.md
- Add change log.

### README.md
- Add property to example code.

### ddlparse/\_\_init\_\_.py
- Update version.

### ddlparse/ddlparse.py
- Add `DdlParseColumn.character_set` property.
- Add supports for parsing MySQL FOREIGN KEY options MATCH, ON DELETE and ON UPDATE

### example/example.py
- Add property to example code.

### test/test_ddlparse.py
- Add property to test case.
- Add supports for parsing MySQL FOREIGN KEY options MATCH, ON DELETE and ON UPDATE


## Applicable Issues
- fix #56 : Unable to parse MySQL foreign key constraints (ON DELETE, CASCADE)
- fix #57 : Unable to parse MySQL character sets
