### PR TITLE
Add STRING to BQ_DATA_TYPE_DIC["STRING"] to support STRING data type

### DIFF
--- a/ddlparse/ddlparse.py
+++ b/ddlparse/ddlparse.py
@@ -287,7 +287,7 @@ class DdlParseColumn(DdlParseTableColumnBase):
 
         # BigQuery data type = {source_database: [data type, ...], ...}
         BQ_DATA_TYPE_DIC = OrderedDict()
-        BQ_DATA_TYPE_DIC["STRING"] = {None: [re.compile(r"(CHAR|TEXT|CLOB|JSON|UUID)")]}
+        BQ_DATA_TYPE_DIC["STRING"] = {None: [re.compile(r"(STRING|CHAR|TEXT|CLOB|JSON|UUID)")]}
         BQ_DATA_TYPE_DIC["INTEGER"] = {None: [re.compile(r"INT|SERIAL|YEAR")]}
         BQ_DATA_TYPE_DIC["FLOAT"] = {None: [re.compile(r"(FLOAT|DOUBLE)"), "REAL", "MONEY"]}
         BQ_DATA_TYPE_DIC["DATETIME"] = {

--- a/test/test_ddlparse.py
+++ b/test/test_ddlparse.py
@@ -63,7 +63,7 @@ TEST_DATA = {
               Col_47 decimal(*, 3),  -- comment
               Col_48 numeric,
               Col_49 number,
-              Col_50 decimal
+              Col_50 decimal,
               Col_51 string(20)
             );
             """,

--- a/test/test_ddlparse.py
+++ b/test/test_ddlparse.py
@@ -64,6 +64,7 @@ TEST_DATA = {
               Col_48 numeric,
               Col_49 number,
               Col_50 decimal
+              Col_51 string(20)
             );
             """,
         "database": None,
@@ -119,6 +120,7 @@ TEST_DATA = {
             {"name": "Col_48", "type": "NUMERIC", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
             {"name": "Col_49", "type": "NUMBER", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
             {"name": "Col_50", "type": "DECIMAL", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
+            {"name": "Col_51", "type": "STRING", "length": 20, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
         ],
         "bq_field": [
             '{"name": "Col_01", "type": "STRING", "mode": "REQUIRED"}',
@@ -171,6 +173,7 @@ TEST_DATA = {
             '{"name": "Col_48", "type": "INTEGER", "mode": "NULLABLE"}',
             '{"name": "Col_49", "type": "INTEGER", "mode": "NULLABLE"}',
             '{"name": "Col_50", "type": "INTEGER", "mode": "NULLABLE"}',
+            '{"name": "Col_51", "type": "STRING", "mode": "NULLABLE"}',
         ],
         "bq_standard_data_type": [
             "STRING",
@@ -223,6 +226,7 @@ TEST_DATA = {
             "INT64",
             "INT64",
             "INT64",
+            "STRING",
         ],
     },
 


### PR DESCRIPTION
## Summary
<!-- Changelog format : https://keepachangelog.com/ -->

Added `STRING` to `BQ_DATA_TYPE_DIC["STRING"]` to support schema conversion when DDL contains `STRING` data type (for example BigQuery DDLs, see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#string_type).

### Added
- `STRING` to `BQ_DATA_TYPE_DIC["STRING"]`
- Unit-test to reflect above

### Changed
- n/a

### Removed
- n/a

### Fixed
- n/a

## File Details
### `ddlparse/ddlparse.py`
- See above


## Applicable Issues
- n/a
