### PR TITLE
Add BYTES to BQ_DATA_TYPE_DIC to support BYTES datatype

### DIFF
--- a/ddlparse/ddlparse.py
+++ b/ddlparse/ddlparse.py
@@ -298,6 +298,7 @@ class DdlParseColumn(DdlParseTableColumnBase):
         BQ_DATA_TYPE_DIC["DATE"] = {None: ["DATE"]}
         BQ_DATA_TYPE_DIC["TIME"] = {None: ["TIME"]}
         BQ_DATA_TYPE_DIC["BOOLEAN"] = {None: [re.compile(r"BOOL")]}
+        BQ_DATA_TYPE_DIC["BYTES"] = {None: ["BYTES"]}
 
         for bq_type, conditions in BQ_DATA_TYPE_DIC.items():
             for source_db, source_datatypes in conditions.items():

--- a/test/test_ddlparse.py
+++ b/test/test_ddlparse.py
@@ -64,7 +64,8 @@ TEST_DATA = {
               Col_48 numeric,
               Col_49 number,
               Col_50 decimal,
-              Col_51 string(20)
+              Col_51 string(20),
+              Col_52 bytes(20)
             );
             """,
         "database": None,
@@ -121,6 +122,7 @@ TEST_DATA = {
             {"name": "Col_49", "type": "NUMBER", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
             {"name": "Col_50", "type": "DECIMAL", "length": None, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
             {"name": "Col_51", "type": "STRING", "length": 20, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
+            {"name": "Col_52", "type": "BYTES", "length": 20, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "constraint": "", "description": None},
         ],
         "bq_field": [
             '{"name": "Col_01", "type": "STRING", "mode": "REQUIRED"}',
@@ -174,6 +176,7 @@ TEST_DATA = {
             '{"name": "Col_49", "type": "INTEGER", "mode": "NULLABLE"}',
             '{"name": "Col_50", "type": "INTEGER", "mode": "NULLABLE"}',
             '{"name": "Col_51", "type": "STRING", "mode": "NULLABLE"}',
+            '{"name": "Col_52", "type": "BYTES", "mode": "NULLABLE"}',
         ],
         "bq_standard_data_type": [
             "STRING",
@@ -227,6 +230,7 @@ TEST_DATA = {
             "INT64",
             "INT64",
             "STRING",
+            "BYTES",
         ],
     },
 


### PR DESCRIPTION
## Summary
<!-- Changelog format : https://keepachangelog.com/ -->

Similar to https://github.com/shinichi-takii/ddlparse/pull/62

Added BYTES to BQ_DATA_TYPE_DIC to support schema conversion when DDL contains BYTES data type (for example BigQuery DDLs, see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#bytes_type).

### Added
- `BYTES` to `BQ_DATA_TYPE_DIC`
- Unit-test to reflect above

### Changed
- n/a

### Removed
- n/a

### Fixed
- n/a

## File Details
### `ddlparse/ddlparse.py`
- See above


## Applicable Issues
- #63
