### PR TITLE
Fix issue with NULL columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 # command to install dependencies
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.10.0] - 2021-07-10
+### Added
+- Added supports for Python 3.9
+
+### Fixed
+- Fixed parsing of columns with NULL/NOT NULL constraint.
+
+
 ## [1.9.0] - 2020-11-04
 ### Added
 - Add supports Cloud Spanner data-type.
@@ -58,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `FIXED`
 
 ### Fixed
-- Miner fix.
+- Minor fix.
 
 
 ## [1.5.0] - 2020-07-06
@@ -70,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix parse for column-constraint.
-- Miner fix.
+- Minor fix.
 
 
 ## [1.4.0] - 2019-12-08
@@ -161,7 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `NUMBER` with no length & scale specification
 
 ### Fixed
-- Miner fix.
+- Minor fix.
 
 
 ## [1.1.1] - 2018-03-25
@@ -182,15 +190,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.2] - 2018-01-09
 ### Fixed
-- Miner enhancement.
+- Minor enhancement.
     - `ddlparse.py` : Exclude unused module.
     - `example.py` : Modified comment.
-    - `README.md` : Miner fix.
+    - `README.md` : Minor fix.
 
 
 ## [1.0.1] - 2018-01-07
 ### Fixed
-- Miner enhancement.
+- Minor enhancement.
 
 
 ## [1.0.0]
@@ -198,6 +206,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial released.
 
 
+[1.10.0]: https://github.com/shinichi-takii/ddlparse/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/shinichi-takii/ddlparse/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/shinichi-takii/ddlparse/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/shinichi-takii/ddlparse/compare/v1.6.1...v1.7.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/ddlparse.svg)](https://pypi.org/project/ddlparse/)
 [![Python version](https://img.shields.io/pypi/pyversions/ddlparse.svg)](https://pypi.org/project/ddlparse/)
-[![Travis CI Build Status](https://travis-ci.org/shinichi-takii/ddlparse.svg?branch=master)](https://travis-ci.org/shinichi-takii/ddlparse)
+[![Travis CI Build Status](https://travis-ci.com/shinichi-takii/ddlparse.svg?branch=master)](https://travis-ci.com/shinichi-takii/ddlparse)
 [![Coveralls Coverage Status](https://coveralls.io/repos/github/shinichi-takii/ddlparse/badge.svg?branch=master)](https://coveralls.io/github/shinichi-takii/ddlparse?branch=master)
 [![codecov Coverage Status](https://codecov.io/gh/shinichi-takii/ddlparse/branch/master/graph/badge.svg)](https://codecov.io/gh/shinichi-takii/ddlparse)
 [![Requirements Status](https://requires.io/github/shinichi-takii/ddlparse/requirements.svg?branch=master)](https://requires.io/github/shinichi-takii/ddlparse/requirements/?branch=master)

--- a/ddlparse/__init__.py
+++ b/ddlparse/__init__.py
@@ -7,8 +7,8 @@
 
 from .ddlparse import *
 
-__copyright__    = 'Copyright (C) 2018-2020 Shinichi Takii'
-__version__      = '1.9.0'
+__copyright__    = 'Copyright (C) 2018-2021 Shinichi Takii'
+__version__      = '1.10.0'
 __license__      = 'BSD-3-Clause'
 __author__       = 'Shinichi Takii'
 __author_email__ = 'shinichi.takii@shaketh.com'

--- a/ddlparse/ddlparse.py
+++ b/ddlparse/ddlparse.py
@@ -578,8 +578,8 @@ class DdlParse(DdlParseBase):
     """DDL parser"""
 
     _LPAR, _RPAR, _COMMA, _SEMICOLON, _DOT, _DOUBLEQUOTE, _BACKQUOTE, _SPACE = map(Suppress, "(),;.\"` ")
-    _CREATE, _TABLE, _TEMP, _CONSTRAINT, _NOT_NULL, _PRIMARY_KEY, _UNIQUE, _UNIQUE_KEY, _FOREIGN_KEY, _REFERENCES, _KEY, _CHAR_SEMANTICS, _BYTE_SEMANTICS = \
-        map(CaselessKeyword, "CREATE, TABLE, TEMP, CONSTRAINT, NOT NULL, PRIMARY KEY, UNIQUE, UNIQUE KEY, FOREIGN KEY, REFERENCES, KEY, CHAR, BYTE".replace(", ", ",").split(","))
+    _CREATE, _TABLE, _TEMP, _CONSTRAINT, _NOT_NULL, _NULL, _PRIMARY_KEY, _UNIQUE, _UNIQUE_KEY, _FOREIGN_KEY, _REFERENCES, _KEY, _CHAR_SEMANTICS, _BYTE_SEMANTICS = \
+        map(CaselessKeyword, "CREATE, TABLE, TEMP, CONSTRAINT, NOT NULL, NULL, PRIMARY KEY, UNIQUE, UNIQUE KEY, FOREIGN KEY, REFERENCES, KEY, CHAR, BYTE".replace(", ", ",").split(","))
     _TYPE_UNSIGNED, _TYPE_ZEROFILL = \
         map(CaselessKeyword, "UNSIGNED, ZEROFILL".replace(", ", ",").split(","))
     _COL_ATTR_DISTKEY, _COL_ATTR_SORTKEY, _COL_ATTR_CHARACTER_SET = \
@@ -645,7 +645,7 @@ class DdlParse(DdlParseBase):
                     + Optional(
                         Regex(r"(?!--)", re.IGNORECASE)
                         + Group(
-                            Optional(Regex(r"\b(?:NOT\s+)NULL?\b", re.IGNORECASE))("null")
+                            Optional(_NOT_NULL ^ _NULL)("null")
                             & Optional(Regex(r"\bAUTO_INCREMENT\b", re.IGNORECASE))("auto_increment")
                             & Optional(Regex(r"\b(UNIQUE|PRIMARY)(?:\s+KEY)?\b", re.IGNORECASE))("key")
                             & Optional(Regex(

--- a/ddlparse/ddlparse.py
+++ b/ddlparse/ddlparse.py
@@ -578,8 +578,8 @@ class DdlParse(DdlParseBase):
     """DDL parser"""
 
     _LPAR, _RPAR, _COMMA, _SEMICOLON, _DOT, _DOUBLEQUOTE, _BACKQUOTE, _SPACE = map(Suppress, "(),;.\"` ")
-    _CREATE, _TABLE, _TEMP, _CONSTRAINT, _NOT_NULL, _NULL, _PRIMARY_KEY, _UNIQUE, _UNIQUE_KEY, _FOREIGN_KEY, _REFERENCES, _KEY, _CHAR_SEMANTICS, _BYTE_SEMANTICS = \
-        map(CaselessKeyword, "CREATE, TABLE, TEMP, CONSTRAINT, NOT NULL, NULL, PRIMARY KEY, UNIQUE, UNIQUE KEY, FOREIGN KEY, REFERENCES, KEY, CHAR, BYTE".replace(", ", ",").split(","))
+    _CREATE, _TABLE, _TEMP, _CONSTRAINT, _NOT_NULL, _PRIMARY_KEY, _UNIQUE, _UNIQUE_KEY, _FOREIGN_KEY, _REFERENCES, _KEY, _CHAR_SEMANTICS, _BYTE_SEMANTICS = \
+        map(CaselessKeyword, "CREATE, TABLE, TEMP, CONSTRAINT, NOT NULL, PRIMARY KEY, UNIQUE, UNIQUE KEY, FOREIGN KEY, REFERENCES, KEY, CHAR, BYTE".replace(", ", ",").split(","))
     _TYPE_UNSIGNED, _TYPE_ZEROFILL = \
         map(CaselessKeyword, "UNSIGNED, ZEROFILL".replace(", ", ",").split(","))
     _COL_ATTR_DISTKEY, _COL_ATTR_SORTKEY, _COL_ATTR_CHARACTER_SET = \
@@ -645,7 +645,7 @@ class DdlParse(DdlParseBase):
                     + Optional(
                         Regex(r"(?!--)", re.IGNORECASE)
                         + Group(
-                            Optional(_NOT_NULL ^ _NULL)("null")
+                            Optional(Regex(r"\b(?:NOT\s+)?NULL?\b", re.IGNORECASE))("null")
                             & Optional(Regex(r"\bAUTO_INCREMENT\b", re.IGNORECASE))("auto_increment")
                             & Optional(Regex(r"\b(UNIQUE|PRIMARY)(?:\s+KEY)?\b", re.IGNORECASE))("key")
                             & Optional(Regex(

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Database',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/test/test_ddlparse.py
+++ b/test/test_ddlparse.py
@@ -65,7 +65,9 @@ TEST_DATA = {
               Col_49 number,
               Col_50 decimal,
               Col_51 string(20),
-              Col_52 bytes(20)
+              Col_52 bytes(20),
+              Col_53 char(200) NULL,
+              Col_54 char(200) NOT NULL
             );
             """,
         "database": None,
@@ -123,6 +125,8 @@ TEST_DATA = {
             {"name": "Col_50", "type": "DECIMAL", "length": None, "scale": None},
             {"name": "Col_51", "type": "STRING", "length": 20, "scale": None},
             {"name": "Col_52", "type": "BYTES", "length": 20, "scale": None},
+            {"name": "Col_53", "type": "CHAR", "length": 200, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": False, "pk": False, "unique": False, "description": None},
+            {"name": "Col_54", "type": "CHAR", "length": 200, "scale": None, "array_dimensional": 0, "is_unsigned": False, "is_zerofill": False, "not_null": True, "pk": False, "unique": False, "constraint": "NOT NULL", "description": None},
         ],
         "bq_field": [
             '{"name": "Col_01", "type": "STRING", "mode": "REQUIRED"}',
@@ -177,6 +181,8 @@ TEST_DATA = {
             '{"name": "Col_50", "type": "INTEGER", "mode": "NULLABLE"}',
             '{"name": "Col_51", "type": "STRING", "mode": "NULLABLE"}',
             '{"name": "Col_52", "type": "BYTES", "mode": "NULLABLE"}',
+            '{"name": "Col_53", "type": "STRING", "mode": "NULLABLE"}',
+            '{"name": "Col_54", "type": "STRING", "mode": "REQUIRED"}',
         ],
         "bq_standard_data_type": [
             "STRING",
@@ -231,6 +237,8 @@ TEST_DATA = {
             "INT64",
             "STRING",
             "BYTES",
+            "STRING",
+            "STRING",
         ],
     },
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py35,py36,py37,py38,py39
 
 [testenv]
 deps=


### PR DESCRIPTION
## Summary
As reported in #68, the parser stopped on columns with an explicit NULL definition. With my limited understanding of this package, I've tried to create a fix. I've added some columns in the basic test case which all pass.

### Added
- CaselessKeyword for NULL
- Tests for NULL and NOT NULL columns
- Added supports for Python 3.9

### Changed
- Detection of NULL/NOT NULL constraint now implemented using an Or match without regular expression.
- Migrate Travis-CI domain.

### Removed
- Regular expression for NOT NULL constraints

### Fixed
- #68: Parser stops when it encounters a NULL column definition


## Applicable Issues
- fix #61
- fix #68
