### PR TITLE
Support dots in schema names

### DIFF
--- a/ddlparse/ddlparse.py
+++ b/ddlparse/ddlparse.py
@@ -597,8 +597,11 @@ class DdlParse(DdlParseBase):
     _COMMENT = Suppress("--" + Regex(r".+"))
 
 
+    _SCHEMA = (_SUPPRESS_QUOTE + Word(alphanums + "_" + ".")("schema") + _SUPPRESS_QUOTE) \
+              | (Optional(_SUPPRESS_QUOTE) + Word(alphanums + "_")("schema") + Optional(_SUPPRESS_QUOTE))
+
     _CREATE_TABLE_STATEMENT = Suppress(_CREATE) + Optional(_TEMP)("temp") + Suppress(_TABLE) + Optional(Suppress(CaselessKeyword("IF NOT EXISTS"))) \
-        + Optional(_SUPPRESS_QUOTE) + Optional(Word(alphanums + "_" + ".")("schema") + Optional(_SUPPRESS_QUOTE) + _DOT + Optional(_SUPPRESS_QUOTE)) + Word(alphanums + "_<>")("table") + Optional(_SUPPRESS_QUOTE) \
+        + Optional(_SCHEMA + _DOT) + Optional(_SUPPRESS_QUOTE) + Word(alphanums + "_<>")("table") + Optional(_SUPPRESS_QUOTE) \
         + _LPAR \
         + delimitedList(
             OneOrMore(

--- a/ddlparse/ddlparse.py
+++ b/ddlparse/ddlparse.py
@@ -598,7 +598,7 @@ class DdlParse(DdlParseBase):
 
 
     _CREATE_TABLE_STATEMENT = Suppress(_CREATE) + Optional(_TEMP)("temp") + Suppress(_TABLE) + Optional(Suppress(CaselessKeyword("IF NOT EXISTS"))) \
-        + Optional(_SUPPRESS_QUOTE) + Optional(Word(alphanums + "_")("schema") + Optional(_SUPPRESS_QUOTE) + _DOT + Optional(_SUPPRESS_QUOTE)) + Word(alphanums + "_<>")("table") + Optional(_SUPPRESS_QUOTE) \
+        + Optional(_SUPPRESS_QUOTE) + Optional(Word(alphanums + "_" + ".")("schema") + Optional(_SUPPRESS_QUOTE) + _DOT + Optional(_SUPPRESS_QUOTE)) + Word(alphanums + "_<>")("table") + Optional(_SUPPRESS_QUOTE) \
         + _LPAR \
         + delimitedList(
             OneOrMore(

--- a/ddlparse/ddlparse.py
+++ b/ddlparse/ddlparse.py
@@ -596,9 +596,9 @@ class DdlParse(DdlParseBase):
 
     _COMMENT = Suppress("--" + Regex(r".+"))
 
-
-    _SCHEMA = (_SUPPRESS_QUOTE + Word(alphanums + "_" + ".")("schema") + _SUPPRESS_QUOTE) \
-              | (Optional(_SUPPRESS_QUOTE) + Word(alphanums + "_")("schema") + Optional(_SUPPRESS_QUOTE))
+    _schema_chars = alphanums + "_"
+    _SCHEMA = (_SUPPRESS_QUOTE + Word(_schema_chars + ".")("schema") + _SUPPRESS_QUOTE) \
+              | (Optional(_SUPPRESS_QUOTE) + Word(_schema_chars)("schema") + Optional(_SUPPRESS_QUOTE))
 
     _CREATE_TABLE_STATEMENT = Suppress(_CREATE) + Optional(_TEMP)("temp") + Suppress(_TABLE) + Optional(Suppress(CaselessKeyword("IF NOT EXISTS"))) \
         + Optional(_SCHEMA + _DOT) + Optional(_SUPPRESS_QUOTE) + Word(alphanums + "_<>")("table") + Optional(_SUPPRESS_QUOTE) \

--- a/test/test_ddlparse.py
+++ b/test/test_ddlparse.py
@@ -1365,3 +1365,10 @@ def test_constraint_compatibility():
     assert dl_col.primary_key is True
     assert dl_col.unique is False
     assert dl_col.comment == 'foo'
+
+
+def test_ddl_with_dot_schema():
+    ddl = """
+    create table "foo.bar"."bazz" ( id int );
+    """
+    DdlParse(ddl).parse()

--- a/test/test_ddlparse.py
+++ b/test/test_ddlparse.py
@@ -1371,4 +1371,6 @@ def test_ddl_with_dot_schema():
     ddl = """
     create table "foo.bar"."bazz" ( id int );
     """
-    DdlParse(ddl).parse()
+    table = DdlParse(ddl).parse()
+    assert table.schema == "foo.bar"
+    assert table.name == "bazz"


### PR DESCRIPTION
## Summary
In #71 it was demonstrated that a schema with a dot `.` in the name would cause a parsing error. This patch allows supporting this naming style.

### Added
- Support for dot in schema
- Test for dot in schema name

### Changed
- Update possible chars for schema

### Removed
NA

### Fixed
NA


## File Details
### ddlparse.py


## Applicable Issues
- fix #71 
